### PR TITLE
feat(pkgs): add lazyvim package for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ Example `home-manager/home.nix`:
 }
 ```
 
+Run LazyVim with some default config for testing:
+
+```sh
+nix run --extra-experimental-features "nix-command flakes" github:matadaniel/LazyVim-module
+```
+
 ## 📖 Usage
 
 Enable extras

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1727348695,
-        "narHash": "sha256-J+PeFKSDV+pHL7ukkfpVzCOO7mBSrrpJ3svwBFABbhI=",
+        "lastModified": 1733759999,
+        "narHash": "sha256-463SNPWmz46iLzJKRzO3Q2b0Aurff3U1n0nYItxq7jU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1925c603f17fc89f4c8f6bf6f631a802ad85d784",
+        "rev": "a73246e2eef4c6ed172979932bc80e1404ba2d56",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -23,24 +23,18 @@
         lazyvim = import ./lazyvim self;
       };
 
-      nixosModules = {
-        default = self.nixosModules.lazyvim;
-        lazyvim = import ./pkgs/lazyvim/module.nix self;
-      };
-
       packages = nixpkgs.lib.genAttrs (import systems) (
         system:
         let
           inherit (import nixpkgs { inherit system; }) callPackage;
         in
-        rec {
+        {
           astro-ts-plugin = callPackage ./pkgs/astro-ts-plugin { };
           markdown-toc = callPackage ./pkgs/markdown-toc { };
           typescript-svelte-plugin = callPackage ./pkgs/typescript-svelte-plugin { };
-          lazyvim = callPackage ./pkgs/lazyvim {
+          default = callPackage ./pkgs/lazyvim {
             inherit self inputs;
           };
-          default = lazyvim;
         }
       );
     };

--- a/flake.nix
+++ b/flake.nix
@@ -16,11 +16,16 @@
       self,
       systems,
       ...
-    }:
+    }@inputs:
     {
       homeManagerModules = {
         default = self.homeManagerModules.lazyvim;
         lazyvim = import ./lazyvim self;
+      };
+
+      nixosModules = {
+        default = self.nixosModules.lazyvim;
+        lazyvim = import ./pkgs/lazyvim/module.nix self;
       };
 
       packages = nixpkgs.lib.genAttrs (import systems) (
@@ -28,10 +33,14 @@
         let
           inherit (import nixpkgs { inherit system; }) callPackage;
         in
-        {
+        rec {
           astro-ts-plugin = callPackage ./pkgs/astro-ts-plugin { };
           markdown-toc = callPackage ./pkgs/markdown-toc { };
           typescript-svelte-plugin = callPackage ./pkgs/typescript-svelte-plugin { };
+          lazyvim = callPackage ./pkgs/lazyvim {
+            inherit self inputs;
+          };
+          default = lazyvim;
         }
       );
     };

--- a/lazyvim/default.nix
+++ b/lazyvim/default.nix
@@ -173,6 +173,30 @@ in
         				"tutor",
         				"zipPlugin",
         			},
+        			paths = {
+        				${
+              let
+                wrapPlugins =
+                  plugins:
+                  map (plugin: {
+                    key = plugin.outPath;
+                    deps = plugin.dependencies or [ ];
+                  }) plugins;
+              in
+              builtins.concatStringsSep "\n\t\t\t\t" (
+                map ({ key, deps }: "\"${key}\",") (
+                  builtins.genericClosure {
+                    startSet = wrapPlugins (
+                      builtins.concatMap (
+                        plugin: plugin.dependencies or [ ]
+                      ) config.programs.neovim.finalPackage.passthru.packpathDirs.myNeovimPackages.start
+                    );
+                    operator = { key, deps }: wrapPlugins deps;
+                  }
+                )
+              )
+            }
+        			},
         		},
         	},
         })

--- a/lazyvim/default.nix
+++ b/lazyvim/default.nix
@@ -173,30 +173,6 @@ in
         				"tutor",
         				"zipPlugin",
         			},
-        			paths = {
-        				${
-              let
-                wrapPlugins =
-                  plugins:
-                  map (plugin: {
-                    key = plugin.outPath;
-                    deps = plugin.dependencies or [ ];
-                  }) plugins;
-              in
-              builtins.concatStringsSep "\n\t\t\t\t" (
-                map ({ key, deps }: "\"${key}\",") (
-                  builtins.genericClosure {
-                    startSet = wrapPlugins (
-                      builtins.concatMap (
-                        plugin: plugin.dependencies or [ ]
-                      ) config.programs.neovim.finalPackage.passthru.packpathDirs.myNeovimPackages.start
-                    );
-                    operator = { key, deps }: wrapPlugins deps;
-                  }
-                )
-              )
-            }
-        			},
         		},
         	},
         })

--- a/pkgs/lazyvim/config.nix
+++ b/pkgs/lazyvim/config.nix
@@ -4,6 +4,7 @@
     fish.enable = true;
     wofi.enable = true;
     rofi.enable = true;
+    neovim.finalPackage.passthru.packpathDirs.myNeovimPackages.start = [ ];
     lazyvim = {
       enable = true;
       extras = {
@@ -57,12 +58,7 @@
         };
       };
       plugins = [ ];
-      pluginsToDisable = [
-        {
-          lazyName = "plugins";
-          nixName = "plugins";
-        }
-      ];
+      pluginsToDisable = [ ];
       pluginsFile = null;
     };
   };

--- a/pkgs/lazyvim/config.nix
+++ b/pkgs/lazyvim/config.nix
@@ -30,13 +30,13 @@
 
         lang = {
           nix.enable = true;
-          astro.enable = false;
+          astro.enable = true;
           svelte.enable = false;
           tailwind.enable = false;
           prisma.enable = false;
-          markdown.enable = false;
-          json.enable = false;
-          typescript.enable = false;
+          markdown.enable = true;
+          json.enable = true;
+          typescript.enable = true;
         };
 
         linting = {

--- a/pkgs/lazyvim/config.nix
+++ b/pkgs/lazyvim/config.nix
@@ -1,3 +1,4 @@
+# Set some default configuration for Home Manager- and LazyVim-modules
 {
   wayland.windowManager.hyprland.enable = true;
   programs = {

--- a/pkgs/lazyvim/config.nix
+++ b/pkgs/lazyvim/config.nix
@@ -1,4 +1,3 @@
-# Set some default configuration for Home Manager- and LazyVim-modules
 {
   wayland.windowManager.hyprland.enable = true;
   programs = {
@@ -11,7 +10,6 @@
       extras = {
         coding = {
           mini-surround.enable = true;
-
           yanky.enable = true;
         };
 
@@ -21,7 +19,6 @@
 
         editor = {
           dial.enable = true;
-
           inc-rename.enable = true;
         };
 
@@ -30,13 +27,13 @@
         };
 
         lang = {
-          nix.enable = true;
           astro.enable = true;
-          svelte.enable = false;
-          tailwind.enable = false;
-          prisma.enable = false;
-          markdown.enable = true;
           json.enable = true;
+          markdown.enable = true;
+          nix.enable = true;
+          prisma.enable = true;
+          svelte.enable = true;
+          tailwind.enable = true;
           typescript.enable = true;
         };
 
@@ -48,14 +45,14 @@
           core.enable = true;
         };
 
+        ui = {
+          mini-animate.enable = true;
+        };
+
         util = {
           dot.enable = true;
 
           mini-hipatterns.enable = true;
-        };
-
-        ui = {
-          mini-animate.enable = false;
         };
       };
       plugins = [ ];

--- a/pkgs/lazyvim/config.nix
+++ b/pkgs/lazyvim/config.nix
@@ -1,0 +1,69 @@
+{
+  wayland.windowManager.hyprland.enable = true;
+  programs = {
+    fish.enable = true;
+    wofi.enable = true;
+    rofi.enable = true;
+    lazyvim = {
+      enable = true;
+      extras = {
+        coding = {
+          mini-surround.enable = true;
+
+          yanky.enable = true;
+        };
+
+        dap = {
+          core.enable = true;
+        };
+
+        editor = {
+          dial.enable = true;
+
+          inc-rename.enable = true;
+        };
+
+        formatting = {
+          prettier.enable = true;
+        };
+
+        lang = {
+          nix.enable = true;
+          astro.enable = false;
+          svelte.enable = false;
+          tailwind.enable = false;
+          prisma.enable = false;
+          markdown.enable = false;
+          json.enable = false;
+          typescript.enable = false;
+        };
+
+        linting = {
+          eslint.enable = true;
+        };
+
+        test = {
+          core.enable = true;
+        };
+
+        util = {
+          dot.enable = true;
+
+          mini-hipatterns.enable = true;
+        };
+
+        ui = {
+          mini-animate.enable = false;
+        };
+      };
+      plugins = [ ];
+      pluginsToDisable = [
+        {
+          lazyName = "plugins";
+          nixName = "plugins";
+        }
+      ];
+      pluginsFile = null;
+    };
+  };
+}

--- a/pkgs/lazyvim/config.nix
+++ b/pkgs/lazyvim/config.nix
@@ -4,6 +4,8 @@
     fish.enable = true;
     wofi.enable = true;
     rofi.enable = true;
+    lazygit.enable = true;
+    ripgrep.enable = true;
     neovim.finalPackage.passthru.packpathDirs.myNeovimPackages.start = [ ];
     lazyvim = {
       enable = true;

--- a/pkgs/lazyvim/default.nix
+++ b/pkgs/lazyvim/default.nix
@@ -9,7 +9,7 @@ let
     config:
     lib.evalModules {
       modules = [
-        (self.nixosModules.lazyvim)
+        (import ./module.nix self)
         (self.homeManagerModules.lazyvim)
       ];
       specialArgs = {
@@ -23,9 +23,9 @@ let
     };
 
   defaultConfig = import ./config.nix;
-  lazyvim-config = (evalLazyVimModule defaultConfig).config;
+  lazyvimConfig = (evalLazyVimModule defaultConfig).config;
 
-  xdgConfigFile = lazyvim-config.xdg.configFile;
+  xdgConfigFile = lazyvimConfig.xdg.configFile;
   filteredConfigFiles = pkgs.lib.filterAttrs (
     name: value: pkgs.lib.hasPrefix "nvim/lua/plugins" name
   ) xdgConfigFile;
@@ -48,7 +48,7 @@ let
     '';
   };
 
-  neovimConfig = lazyvim-config.programs.neovim;
+  neovimConfig = lazyvimConfig.programs.neovim;
   lazyvim = pkgs.wrapNeovim pkgs.neovim-unwrapped {
     configure = {
       customRC = # vim

--- a/pkgs/lazyvim/default.nix
+++ b/pkgs/lazyvim/default.nix
@@ -52,6 +52,11 @@ let
   };
 
   neovimConfig = lazyvimConfig.programs.neovim;
+  extraPackages =
+    neovimConfig.extraPackages
+    ++ (lib.optional defaultConfig.programs.lazygit.enable pkgs.lazygit)
+    ++ (lib.optional defaultConfig.programs.ripgrep.enable pkgs.ripgrep);
+
   lazyvim = pkgs.wrapNeovim pkgs.neovim-unwrapped {
     configure = {
       customRC = # vim
@@ -68,10 +73,12 @@ let
 in
 pkgs.writeShellScriptBin "neovim" ''
   export XDG_CONFIG_HOME=$(mktemp -d)
+  mkdir $XDG_CONFIG_HOME/lazygit
+  touch $XDG_CONFIG_HOME/lazygit/config.yml
   pluginsDir=$XDG_CONFIG_HOME/nvim/lua/plugins
   mkdir -p $pluginsDir
   ln -sf ${xdgConfigDerivation}/* $pluginsDir
 
-  export PATH="$PATH:${lib.makeBinPath neovimConfig.extraPackages}"
+  export PATH="$PATH:${lib.makeBinPath extraPackages}"
   exec ${lazyvim}/bin/nvim "$@"
 ''

--- a/pkgs/lazyvim/default.nix
+++ b/pkgs/lazyvim/default.nix
@@ -26,23 +26,26 @@ let
   lazyvimConfig = (evalLazyVimModule defaultConfig).config;
 
   xdgConfigFile = lazyvimConfig.xdg.configFile;
-  filteredConfigFiles = pkgs.lib.filterAttrs (
-    name: value: pkgs.lib.hasPrefix "nvim/lua/plugins" name
+
+  filteredConfigFiles = lib.filterAttrs (
+    name: value: lib.hasPrefix "nvim/lua/plugins" name
   ) xdgConfigFile;
-  writtenConfigFiles = pkgs.lib.mapAttrsToList (
+
+  writtenConfigFiles = lib.mapAttrsToList (
     name: value:
-    if pkgs.lib.hasAttr "text" value && value.text != null then
+    if lib.hasAttr "text" value && value.text != null then
       pkgs.writeText name value.text
-    else if pkgs.lib.hasAttr "source" value && value.source != null then
+    else if lib.hasAttr "source" value && value.source != null then
       pkgs.runCommandNoCC name { } "cp ${value.source} $out"
     else
       throw "Invalid configFile: ${name}"
   ) filteredConfigFiles;
+
   xdgConfigDerivation = pkgs.stdenv.mkDerivation {
     name = "xdg-nvim-config-files";
     buildCommand = ''
       mkdir $out
-      for file in ${pkgs.lib.concatStringsSep " " writtenConfigFiles}; do
+      for file in ${lib.concatStringsSep " " writtenConfigFiles}; do
         cp $file $out
       done
     '';
@@ -69,6 +72,6 @@ pkgs.writeShellScriptBin "neovim" ''
   mkdir -p $pluginsDir
   ln -sf ${xdgConfigDerivation}/* $pluginsDir
 
-  export PATH="$PATH:${pkgs.lib.makeBinPath neovimConfig.extraPackages}"
+  export PATH="$PATH:${lib.makeBinPath neovimConfig.extraPackages}"
   exec ${lazyvim}/bin/nvim "$@"
 ''

--- a/pkgs/lazyvim/default.nix
+++ b/pkgs/lazyvim/default.nix
@@ -1,0 +1,43 @@
+{
+  pkgs,
+  lib,
+  inputs,
+  self,
+}:
+let
+  lazyvim-module-evaluation = lib.evalModules {
+    modules = [
+      (self.nixosModules.lazyvim)
+      (self.homeManagerModules.lazyvim)
+    ];
+    specialArgs = {
+      inherit
+        inputs
+        lib
+        pkgs
+        ;
+      config = import ./config.nix;
+    };
+  };
+
+  programs = lazyvim-module-evaluation.config.programs;
+  neovim-config = programs.neovim;
+  lazyvim = pkgs.wrapNeovim pkgs.neovim-unwrapped {
+    configure = {
+      customRC = # vim
+        ''
+          lua << EOF
+            ${neovim-config.extraLuaConfig}
+          EOF
+        '';
+      packages.myNeovimPackages = {
+        start = neovim-config.plugins;
+      };
+    };
+  };
+in
+pkgs.writeShellScriptBin "neovim" ''
+  export PATH="$PATH:${pkgs.lib.makeBinPath neovim-config.extraPackages}"
+  export NVIM_APPNAME="LazyVim-module-app"
+  exec ${lazyvim}/bin/nvim "$@"
+''

--- a/pkgs/lazyvim/module.nix
+++ b/pkgs/lazyvim/module.nix
@@ -10,7 +10,6 @@ let
   inherit (lib.options) mkEnableOption mkOption;
 in
 {
-  # Mimic configuration options of NixOs and Home Manager modules used by LazyVim-module.
   options = {
     xdg = {
       configFile = lib.mkOption {

--- a/pkgs/lazyvim/module.nix
+++ b/pkgs/lazyvim/module.nix
@@ -1,0 +1,41 @@
+self:
+{
+  config,
+  inputs,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib.options) mkEnableOption mkOption;
+in
+{
+  # Mimic configuration of Home Manager modules used by LazyVim-module.
+  options = {
+    xdg = {
+      configFile = mkOption {
+        type = lib.types.str;
+      };
+    };
+    programs = {
+      neovim = {
+        enable = mkEnableOption "neovim";
+        plugins = mkOption {
+          type = lib.types.listOf lib.types.package;
+          default = [ ];
+          description = "Plugins";
+        };
+        extraLuaConfig = mkOption {
+          type = lib.types.str;
+          default = "";
+          description = "extra lua config";
+        };
+        extraPackages = mkOption {
+          type = lib.types.listOf lib.types.package;
+          default = [ ];
+          description = "extra packages";
+        };
+      };
+    };
+  };
+}

--- a/pkgs/lazyvim/module.nix
+++ b/pkgs/lazyvim/module.nix
@@ -10,7 +10,7 @@ let
   inherit (lib.options) mkEnableOption mkOption;
 in
 {
-  # Mimic configuration of Home Manager modules used by LazyVim-module.
+  # Mimic configuration options of NixOs and Home Manager modules used by LazyVim-module.
   options = {
     xdg = {
       configFile = lib.mkOption {

--- a/pkgs/lazyvim/module.nix
+++ b/pkgs/lazyvim/module.nix
@@ -13,8 +13,26 @@ in
   # Mimic configuration of Home Manager modules used by LazyVim-module.
   options = {
     xdg = {
-      configFile = mkOption {
-        type = lib.types.str;
+      configFile = lib.mkOption {
+        type = lib.types.attrsOf (
+          lib.types.submodule {
+            options = {
+              enable = mkEnableOption "Whether this file should be generated.";
+              source = mkOption {
+                type = lib.types.path;
+                default = null;
+                description = "Path of the source file or directory.";
+              };
+              text = mkOption {
+                type = lib.types.nullOr lib.types.str;
+                default = null;
+                description = "Text content of the file.";
+              };
+            };
+          }
+        );
+        default = { };
+        description = "Configuration files managed by xdg.";
       };
     };
     programs = {


### PR DESCRIPTION
Hey, thanks again for your project!

I'm building my own home-manager module on top of this module, and I also want the ability to quickly run LazyVim or my custom-LazyVim flake.

The benefits I see for having a dedicated package in addition to home-manager:

- Faster trial-error iterations in development by evaluating the flake and not the whole home-manager config
- Having a configured editor runnable, even if I broke my home-manager setup (for example, while developing the LazyVim-module)

Do you see any further issues / ideas?

I may use this opportunity to tell you I've implemented some more LazyVim extras, [over here](https://github.com/arminfro/LazyVim-module/commits/fork/). I'm going to create pull requests for most soon.
