### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Example `flake.nix`:
     };
 
     # add LazyVim-module
-    LazyVim = {
+    lazyvim = {
       url = "github:matadaniel/LazyVim-module";
       inputs.nixpkgs.follows = "nixpkgs";
     };
@@ -56,7 +56,7 @@ Example `home-manager/home.nix`:
 ```nix
 { inputs, ... }:
 {
-  imports = [ inputs.LazyVim.homeManagerModules.default ];
+  imports = [ inputs.lazyvim.homeManagerModules.default ];
 
   programs.lazyvim = {
     enable = true;


### PR DESCRIPTION
@matadaniel Please fix the document. Use: 
```nix
lazyvim = {
  url = "github:matadaniel/LazyVim-module";
  inputs.nixpkgs.follows = "nixpkgs";
};
```
and 
```nix
inputs.lazyvim.homeManagerModules.lazyvim
```
I’ve been struggling a lot with [this](https://github.com/matadaniel/LazyVim-module/issues/8) and found that using lowercase `lazyvim` works, also you should use lowercase repo name `lazyvim-module` .