### PR TITLE
nix-system/default-linux  to nix-system/default

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,8 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-
-    systems.url = "github:nix-systems/default-linux";
+    systems.url = "github:nix-systems/default";
   };
 
   outputs =


### PR DESCRIPTION
use nix-system/default mean support all system include darwin and linux