### PR TITLE
default-linux -> default to support all system

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-    systems.url = "github:nix-systems/default-linux";
+    systems.url = "github:nix-systems/default";
   };
 
   outputs =


### PR DESCRIPTION
This make markdown plugin work on darwin
fix https://github.com/matadaniel/LazyVim-module/issues/25